### PR TITLE
エディターUIの改善 (issue #17)

### DIFF
--- a/app/components/editor/TiptapEditor.tsx
+++ b/app/components/editor/TiptapEditor.tsx
@@ -1,3 +1,4 @@
+import type { Content } from "@tiptap/core";
 import Link from "@tiptap/extension-link";
 import Placeholder from "@tiptap/extension-placeholder";
 import { EditorContent, useEditor } from "@tiptap/react";
@@ -18,10 +19,9 @@ import {
   Undo2Icon,
 } from "lucide-react";
 import { useEffect, useRef } from "react";
-import type { Content } from "@tiptap/core";
-import type { StructuredContent } from "@/core/domain/note/valueObject";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
+import type { StructuredContent } from "@/core/domain/note/valueObject";
 
 /**
  * Type adapter to convert between domain StructuredContent and Tiptap's Content type.
@@ -187,7 +187,7 @@ export function TiptapEditor({
     <div className="flex flex-col h-full">
       {/* Toolbar - only show in edit mode */}
       {editable && (
-        <div className="border-b p-2 flex items-center gap-1 flex-wrap">
+        <div className="border-b p-2 flex items-center gap-1 overflow-x-auto">
           <Button
             variant="ghost"
             size="icon"

--- a/app/components/layout/MemoHeader.tsx
+++ b/app/components/layout/MemoHeader.tsx
@@ -1,9 +1,7 @@
-import { EyeIcon, PencilIcon } from "lucide-react";
-import type { StructuredContent } from "@/core/domain/note/valueObject";
 import { NoteActions } from "@/components/note/NoteActions";
 import { NoteTitle } from "@/components/note/NoteTitle";
 import { SaveStatusIndicator } from "@/components/note/SaveStatusIndicator";
-import { Button } from "@/components/ui/button";
+import type { StructuredContent } from "@/core/domain/note/valueObject";
 import type { SaveStatus } from "@/types";
 import { BackButton } from "./BackButton";
 
@@ -11,8 +9,6 @@ export interface MemoHeaderProps {
   content: StructuredContent;
   saveStatus: SaveStatus;
   exporting: boolean;
-  isEditing: boolean;
-  onToggleEdit: () => void;
   onExport: () => void;
   onDelete: () => void;
 }
@@ -21,8 +17,6 @@ export function MemoHeader({
   content,
   saveStatus,
   exporting,
-  isEditing,
-  onToggleEdit,
   onExport,
   onDelete,
 }: MemoHeaderProps) {
@@ -31,24 +25,6 @@ export function MemoHeader({
       <BackButton />
       <NoteTitle content={content} />
       <div className="flex items-center gap-2">
-        <Button
-          variant={isEditing ? "default" : "outline"}
-          size="sm"
-          onClick={onToggleEdit}
-          title={isEditing ? "閲覧モードに切り替え" : "編集モードに切り替え"}
-        >
-          {isEditing ? (
-            <>
-              <PencilIcon className="h-4 w-4 mr-2" />
-              編集中
-            </>
-          ) : (
-            <>
-              <EyeIcon className="h-4 w-4 mr-2" />
-              閲覧中
-            </>
-          )}
-        </Button>
         <SaveStatusIndicator status={saveStatus} />
         <NoteActions
           exporting={exporting}

--- a/app/components/note/NoteActions.tsx
+++ b/app/components/note/NoteActions.tsx
@@ -1,5 +1,11 @@
-import { DownloadIcon, Trash2Icon } from "lucide-react";
+import { DownloadIcon, MoreVerticalIcon, Trash2Icon } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Spinner } from "@/components/ui/spinner";
 
 export interface NoteActionsProps {
@@ -14,25 +20,26 @@ export function NoteActions({
   onDelete,
 }: NoteActionsProps) {
   return (
-    <>
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={onExport}
-        disabled={exporting}
-      >
-        {exporting ? (
-          <Spinner className="h-4 w-4 mr-2" />
-        ) : (
-          <DownloadIcon className="h-4 w-4 mr-2" />
-        )}
-        Export
-      </Button>
-
-      <Button variant="destructive" size="sm" onClick={onDelete}>
-        <Trash2Icon className="h-4 w-4 mr-2" />
-        Delete
-      </Button>
-    </>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" title="More actions">
+          <MoreVerticalIcon className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={onExport} disabled={exporting}>
+          {exporting ? (
+            <Spinner className="h-4 w-4" />
+          ) : (
+            <DownloadIcon className="h-4 w-4" />
+          )}
+          Export
+        </DropdownMenuItem>
+        <DropdownMenuItem variant="destructive" onClick={onDelete}>
+          <Trash2Icon className="h-4 w-4" />
+          Delete
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/app/components/note/SaveStatusIndicator.tsx
+++ b/app/components/note/SaveStatusIndicator.tsx
@@ -7,26 +7,20 @@ export interface SaveStatusIndicatorProps {
 }
 
 export function SaveStatusIndicator({ status }: SaveStatusIndicatorProps) {
+  const statusText =
+    status === "saved"
+      ? "Saved"
+      : status === "saving"
+        ? "Saving..."
+        : "Unsaved";
+
   return (
-    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+    <div className="flex items-center text-muted-foreground" title={statusText}>
       {status === "saved" && (
-        <>
-          <CheckIcon className="h-4 w-4 text-green-600" />
-          <span>Saved</span>
-        </>
+        <CheckIcon className="h-4 w-4 text-green-600" />
       )}
-      {status === "saving" && (
-        <>
-          <Spinner className="h-4 w-4" />
-          <span>Saving...</span>
-        </>
-      )}
-      {status === "unsaved" && (
-        <>
-          <SaveIcon className="h-4 w-4" />
-          <span>Unsaved</span>
-        </>
-      )}
+      {status === "saving" && <Spinner className="h-4 w-4" />}
+      {status === "unsaved" && <SaveIcon className="h-4 w-4" />}
     </div>
   );
 }

--- a/app/context/di.tsx
+++ b/app/context/di.tsx
@@ -1,10 +1,9 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import { Spinner } from "@/components/ui/spinner";
-import { createLocalStorageContainer } from "@/di";
-import type { Container } from "@/core/application/container";
 import type { Database } from "@/core/adapters/tursoWasm/client";
+import type { Container } from "@/core/application/container";
+import { createLocalStorageContainer, createTursoWasmContainer } from "@/di";
 import { useDatabase } from "@/hooks/useDatabase";
-import { createTursoWasmContainer } from "@/di";
 
 const DIContainer = createContext<Container | null>(null);
 

--- a/app/core/adapters/localStorage/noteRepository.test.ts
+++ b/app/core/adapters/localStorage/noteRepository.test.ts
@@ -2,12 +2,16 @@
  * LocalStorage Note Repository Tests
  */
 import { beforeEach, describe, expect, it } from "vitest";
-import { SystemError, SystemErrorCode } from "@/core/application/error";
-import { NotFoundError, NotFoundErrorCode } from "@/core/application/error";
+import {
+  NotFoundError,
+  NotFoundErrorCode,
+  SystemError,
+  SystemErrorCode,
+} from "@/core/application/error";
 import type { Note } from "@/core/domain/note/entity";
 import {
-  createNoteId,
   createNoteContent,
+  createNoteId,
   createText,
 } from "@/core/domain/note/valueObject";
 import { createTagId } from "@/core/domain/tag/valueObject";

--- a/app/core/adapters/localStorage/noteRepository.ts
+++ b/app/core/adapters/localStorage/noteRepository.ts
@@ -248,7 +248,7 @@ export class LocalStorageNoteRepository implements NoteRepository {
 
     try {
       const notes = this.getAllNotes();
-      let notesArray = Array.from(notes.values());
+      const notesArray = Array.from(notes.values());
 
       // Sort
       const sortField = orderBy === "created_at" ? "created_at" : "updated_at";

--- a/app/core/adapters/localStorage/tagRepository.test.ts
+++ b/app/core/adapters/localStorage/tagRepository.test.ts
@@ -2,8 +2,7 @@
  * LocalStorage Tag Repository Tests
  */
 import { beforeEach, describe, expect, it } from "vitest";
-import { SystemError } from "@/core/application/error";
-import { NotFoundError } from "@/core/application/error";
+import { NotFoundError, SystemError } from "@/core/application/error";
 import type { Tag } from "@/core/domain/tag/entity";
 import { createTagId, createTagName } from "@/core/domain/tag/valueObject";
 import { LocalStorageTagRepository } from "./tagRepository";

--- a/app/core/application/note/deleteNote.test.ts
+++ b/app/core/application/note/deleteNote.test.ts
@@ -11,9 +11,9 @@ import { EmptyUnitOfWorkProvider } from "@/core/adapters/empty/unitOfWork";
 import { createNote } from "@/core/domain/note/entity";
 import { createNoteId } from "@/core/domain/note/valueObject";
 import type { Context } from "../context";
-import { createTestContent } from "./test-helpers";
 import { NotFoundError } from "../error";
 import { deleteNote } from "./deleteNote";
+import { createTestContent } from "./test-helpers";
 
 describe("deleteNote", () => {
   let context: Context;

--- a/app/core/application/note/exportNoteAsMarkdown.test.ts
+++ b/app/core/application/note/exportNoteAsMarkdown.test.ts
@@ -10,10 +10,10 @@ import { EmptyTagQueryService } from "@/core/adapters/empty/tagQueryService";
 import { EmptyUnitOfWorkProvider } from "@/core/adapters/empty/unitOfWork";
 import { createNote } from "@/core/domain/note/entity";
 import { createNoteId } from "@/core/domain/note/valueObject";
-import { createTestContent } from "./test-helpers";
 import type { Context } from "../context";
 import { NotFoundError } from "../error";
 import { exportNoteAsMarkdown } from "./exportNoteAsMarkdown";
+import { createTestContent } from "./test-helpers";
 
 describe("exportNoteAsMarkdown", () => {
   let context: Context;

--- a/app/core/application/note/exportNotesAsMarkdown.test.ts
+++ b/app/core/application/note/exportNotesAsMarkdown.test.ts
@@ -10,10 +10,10 @@ import { EmptyTagQueryService } from "@/core/adapters/empty/tagQueryService";
 import { EmptyUnitOfWorkProvider } from "@/core/adapters/empty/unitOfWork";
 import { createNote } from "@/core/domain/note/entity";
 import { createNoteId } from "@/core/domain/note/valueObject";
-import { createTestContent } from "./test-helpers";
 import type { Context } from "../context";
 import { NotFoundError } from "../error";
 import { exportNotesAsMarkdown } from "./exportNotesAsMarkdown";
+import { createTestContent } from "./test-helpers";
 
 describe("exportNotesAsMarkdown", () => {
   let context: Context;

--- a/app/core/application/note/getNote.test.ts
+++ b/app/core/application/note/getNote.test.ts
@@ -10,10 +10,10 @@ import { EmptyTagQueryService } from "@/core/adapters/empty/tagQueryService";
 import { EmptyUnitOfWorkProvider } from "@/core/adapters/empty/unitOfWork";
 import { createNote } from "@/core/domain/note/entity";
 import { createNoteId } from "@/core/domain/note/valueObject";
-import { createTestContent } from "./test-helpers";
 import { createTagId } from "@/core/domain/tag/valueObject";
 import type { Context } from "../context";
 import { getNote } from "./getNote";
+import { createTestContent } from "./test-helpers";
 
 describe("getNote", () => {
   let context: Context;

--- a/app/core/application/note/getNotes.test.ts
+++ b/app/core/application/note/getNotes.test.ts
@@ -10,10 +10,10 @@ import { EmptyTagQueryService } from "@/core/adapters/empty/tagQueryService";
 import { EmptyUnitOfWorkProvider } from "@/core/adapters/empty/unitOfWork";
 import type { Note } from "@/core/domain/note/entity";
 import { createNote } from "@/core/domain/note/entity";
-import { createTestContent } from "./test-helpers";
 import type { PaginationResult } from "@/lib/pagination";
 import type { Context } from "../context";
 import { getNotes } from "./getNotes";
+import { createTestContent } from "./test-helpers";
 
 describe("getNotes", () => {
   let context: Context;

--- a/app/core/application/tag/deleteTagsByNote.test.ts
+++ b/app/core/application/tag/deleteTagsByNote.test.ts
@@ -11,8 +11,8 @@ import { EmptyUnitOfWorkProvider } from "@/core/adapters/empty/unitOfWork";
 import { createNote } from "@/core/domain/note/entity";
 import { createNoteId } from "@/core/domain/note/valueObject";
 import { createTag } from "@/core/domain/tag/entity";
-import { createTestContent } from "../note/test-helpers";
 import type { Context } from "../context";
+import { createTestContent } from "../note/test-helpers";
 import { deleteTagsByNote } from "./deleteTagsByNote";
 
 describe("deleteTagsByNote", () => {

--- a/app/core/application/tag/getTagsByNote.test.ts
+++ b/app/core/application/tag/getTagsByNote.test.ts
@@ -11,8 +11,8 @@ import { EmptyUnitOfWorkProvider } from "@/core/adapters/empty/unitOfWork";
 import { createNote } from "@/core/domain/note/entity";
 import { createNoteId } from "@/core/domain/note/valueObject";
 import { createTag } from "@/core/domain/tag/entity";
-import { createTestContent } from "../note/test-helpers";
 import type { Context } from "../context";
+import { createTestContent } from "../note/test-helpers";
 import { getTagsByNote } from "./getTagsByNote";
 
 describe("getTagsByNote", () => {

--- a/app/core/application/tag/syncNoteTags.test.ts
+++ b/app/core/application/tag/syncNoteTags.test.ts
@@ -11,8 +11,8 @@ import { EmptyUnitOfWorkProvider } from "@/core/adapters/empty/unitOfWork";
 import { createNote } from "@/core/domain/note/entity";
 import { createNoteId } from "@/core/domain/note/valueObject";
 import { createTag } from "@/core/domain/tag/entity";
-import { createTestContent } from "../note/test-helpers";
 import type { Context } from "../context";
+import { createTestContent } from "../note/test-helpers";
 import { syncNoteTags } from "./syncNoteTags";
 
 describe("syncNoteTags", () => {

--- a/app/core/domain/error.ts
+++ b/app/core/domain/error.ts
@@ -1,6 +1,6 @@
 import { NoteErrorCode } from "./note/errorCode";
-import { TagErrorCode } from "./tag/errorCode";
 import { SettingsErrorCode } from "./settings/errorCode";
+import { TagErrorCode } from "./tag/errorCode";
 
 export const BusinessRuleErrorCode = {
   ...NoteErrorCode,

--- a/app/core/domain/note/valueObject.ts
+++ b/app/core/domain/note/valueObject.ts
@@ -4,8 +4,8 @@
  * Defines value objects for the Note domain with business rule validation.
  */
 import { v7 as uuidv7 } from "uuid";
-import type { JsonValue } from "@/lib/json";
 import { BusinessRuleError } from "@/core/domain/error";
+import type { JsonValue } from "@/lib/json";
 import { NoteErrorCode } from "./errorCode";
 
 const NOTE_TEXT_MAX_LENGTH = 100000;

--- a/app/di.ts
+++ b/app/di.ts
@@ -4,7 +4,7 @@ import { BrowserTagExtractorPort } from "@/core/adapters/browser/tagExtractorPor
 import { LocalStorageNoteQueryService } from "@/core/adapters/localStorage/noteQueryService";
 import { LocalStorageTagQueryService } from "@/core/adapters/localStorage/tagQueryService";
 import { LocalStorageUnitOfWorkProvider } from "@/core/adapters/localStorage/unitOfWork";
-import { getDatabase, type Database } from "@/core/adapters/tursoWasm/client";
+import { type Database, getDatabase } from "@/core/adapters/tursoWasm/client";
 import { TursoWasmNoteQueryService } from "@/core/adapters/tursoWasm/noteQueryService";
 import { TursoWasmTagQueryService } from "@/core/adapters/tursoWasm/tagQueryService";
 import { TursoWasmUnitOfWorkProvider } from "@/core/adapters/tursoWasm/unitOfWork";

--- a/app/hooks/useBulkExport.ts
+++ b/app/hooks/useBulkExport.ts
@@ -1,9 +1,9 @@
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
-import { withContainer } from "@/di";
 import { exportNoteAsMarkdown as exportNoteAsMarkdownService } from "@/core/application/note/exportNoteAsMarkdown";
 import type { Note } from "@/core/domain/note/entity";
 import { createNoteId } from "@/core/domain/note/valueObject";
+import { withContainer } from "@/di";
 import { request } from "@/presenters/request";
 
 const exportNoteAsMarkdown = withContainer(exportNoteAsMarkdownService);

--- a/app/hooks/useCreateNote.ts
+++ b/app/hooks/useCreateNote.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from "react";
-import { withContainer } from "@/di";
 import { createNote as createNoteService } from "@/core/application/note/createNote";
 import type { Note } from "@/core/domain/note/entity";
+import { withContainer } from "@/di";
 import {
   defaultNotification,
   type Notification,

--- a/app/hooks/useDatabase.ts
+++ b/app/hooks/useDatabase.ts
@@ -1,10 +1,10 @@
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import {
-  getDatabase,
-  initializeDatabase,
   closeDatabase,
   type Database,
+  getDatabase,
+  initializeDatabase,
 } from "@/core/adapters/tursoWasm/client";
 
 export const useDatabase = (path: string) => {

--- a/app/hooks/useNote.ts
+++ b/app/hooks/useNote.ts
@@ -1,5 +1,4 @@
 import { use, useCallback, useEffect, useRef, useState } from "react";
-import { withContainer } from "@/di";
 import { deleteNote as deleteNoteService } from "@/core/application/note/deleteNote";
 import { exportNoteAsMarkdown as exportNoteWithMarkdownService } from "@/core/application/note/exportNoteAsMarkdown";
 import { getNote as getNoteService } from "@/core/application/note/getNote";
@@ -7,9 +6,10 @@ import { updateNote as updateNoteService } from "@/core/application/note/updateN
 import type { Note } from "@/core/domain/note/entity";
 import type { StructuredContent } from "@/core/domain/note/valueObject";
 import { createNoteId } from "@/core/domain/note/valueObject";
+import { withContainer } from "@/di";
 import { formatError } from "@/presenters/error";
-import { request } from "@/presenters/request";
 import type { Notification } from "@/presenters/notification";
+import { request } from "@/presenters/request";
 
 const getNote = withContainer(getNoteService);
 const updateNote = withContainer(updateNoteService);

--- a/app/hooks/useNoteTags.ts
+++ b/app/hooks/useNoteTags.ts
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react";
-import { withContainer } from "@/di";
 import { useDIContainer } from "@/context/di";
 import { getTagsByNote as getTagsbyNoteService } from "@/core/application/tag/getTagsByNote";
 import { createNoteId } from "@/core/domain/note/valueObject";
 import type { TagWithUsage } from "@/core/domain/tag/entity";
+import { withContainer } from "@/di";
 
 const getTagsByNote = withContainer(getTagsbyNoteService);
 

--- a/app/hooks/useNotes.ts
+++ b/app/hooks/useNotes.ts
@@ -1,8 +1,8 @@
 import { useCallback, useState } from "react";
-import { withContainer } from "@/di";
 import { combinedSearch as combinedSearchService } from "@/core/application/note/combinedSearch";
 import type { Note } from "@/core/domain/note/entity";
 import { createTagId } from "@/core/domain/tag/valueObject";
+import { withContainer } from "@/di";
 import { createPagination } from "@/lib/pagination";
 import type { SortField, SortOrder } from "@/lib/sort-utils";
 import {

--- a/app/hooks/useTags.ts
+++ b/app/hooks/useTags.ts
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import { withContainer } from "@/di";
 import { useDIContainer } from "@/context/di";
 import { getTags as getTagsService } from "@/core/application/tag/getTags";
 import type { TagWithUsage } from "@/core/domain/tag/entity";
+import { withContainer } from "@/di";
 
 const getTags = withContainer(getTagsService);
 

--- a/app/presenters/error.ts
+++ b/app/presenters/error.ts
@@ -1,28 +1,28 @@
-import { isError } from "@/lib/error";
+import {
+  type ConflictError,
+  type ForbiddenError,
+  isConflictError,
+  isForbiddenError,
+  isNotFoundError,
+  isSystemError,
+  isUnauthenticatedError,
+  isValidationError,
+  type NotFoundError,
+  NotFoundErrorCode,
+  type SystemError,
+  SystemErrorCode,
+  type UnauthenticatedError,
+  UnauthenticatedErrorCode,
+  type ValidationError,
+} from "@/core/application/error";
 import {
   type BusinessRuleError,
   isBusinessRuleError,
 } from "@/core/domain/error";
 import { NoteErrorCode } from "@/core/domain/note/errorCode";
-import { TagErrorCode } from "@/core/domain/tag/errorCode";
 import { SettingsErrorCode } from "@/core/domain/settings/errorCode";
-import {
-  type NotFoundError,
-  NotFoundErrorCode,
-  type ConflictError,
-  type UnauthenticatedError,
-  UnauthenticatedErrorCode,
-  type ForbiddenError,
-  type ValidationError,
-  type SystemError,
-  SystemErrorCode,
-  isNotFoundError,
-  isConflictError,
-  isUnauthenticatedError,
-  isForbiddenError,
-  isValidationError,
-  isSystemError,
-} from "@/core/application/error";
+import { TagErrorCode } from "@/core/domain/tag/errorCode";
+import { isError } from "@/lib/error";
 
 export function formatBusinessRuleError(error: BusinessRuleError): string {
   switch (error.code) {

--- a/app/presenters/note.test.ts
+++ b/app/presenters/note.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from "vitest";
-import { extractTitle, generateNotePreview } from "./note";
+import { describe, expect, it } from "vitest";
 import type { StructuredContent } from "@/core/domain/note/valueObject";
+import { extractTitle, generateNotePreview } from "./note";
 
 describe("extractTitle", () => {
   it("should extract first line as title", () => {

--- a/app/presenters/request.test.ts
+++ b/app/presenters/request.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { request } from "./request";
 
 describe("request", () => {

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,6 +1,4 @@
 import { useNavigate } from "react-router";
-import { withContainer } from "@/di";
-import { combinedSearch as combinedSearchService } from "@/core/application/note/combinedSearch";
 import { HomeHeader } from "@/components/layout/HomeHeader";
 import { BulkActionBar } from "@/components/note/BulkActionBar";
 import { CreateNoteFAB } from "@/components/note/CreateNoteFAB";
@@ -9,6 +7,8 @@ import { TagSidebar } from "@/components/tag/TagSidebar";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { useDIContainer } from "@/context/di";
 import { SearchProvider } from "@/context/search";
+import { combinedSearch as combinedSearchService } from "@/core/application/note/combinedSearch";
+import { withContainer } from "@/di";
 import { useBulkExport } from "@/hooks/useBulkExport";
 import { useBulkSelect } from "@/hooks/useBulkSelect";
 import { useCreateNote } from "@/hooks/useCreateNote";

--- a/app/routes/memos.$id.tsx
+++ b/app/routes/memos.$id.tsx
@@ -1,8 +1,10 @@
+import { EyeIcon, PencilIcon } from "lucide-react";
 import { Suspense, use, useCallback } from "react";
 import { useNavigate } from "react-router";
 import { TiptapEditor } from "@/components/editor/TiptapEditor";
 import { MemoHeader } from "@/components/layout/MemoHeader";
 import { DeleteConfirmDialog } from "@/components/note/DeleteConfirmDialog";
+import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { getNote as getNoteService } from "@/core/application/note/getNote";
 import { createNoteId } from "@/core/domain/note/valueObject";
@@ -67,12 +69,10 @@ export function _MemoDetail(props: { fetchNote: ReturnType<typeof getNote> }) {
         content={note.content}
         saveStatus={saveStatus}
         exporting={exporting}
-        isEditing={editable}
-        onToggleEdit={toggleEditable}
         onExport={exportNote}
         onDelete={deleteNote}
       />
-      <div className="flex-1 overflow-hidden p-4">
+      <div className="flex-1 overflow-hidden p-4 relative">
         <div className="h-full bg-card rounded-xl border shadow-sm">
           <TiptapEditor
             content={note.content}
@@ -81,6 +81,19 @@ export function _MemoDetail(props: { fetchNote: ReturnType<typeof getNote> }) {
             editable={editable}
           />
         </div>
+        {/* FAB button to toggle edit/view mode */}
+        <Button
+          size="lg"
+          className="fixed bottom-6 right-6 rounded-full w-14 h-14 shadow-lg"
+          onClick={toggleEditable}
+          title={editable ? "閲覧モードに切り替え" : "編集モードに切り替え"}
+        >
+          {editable ? (
+            <EyeIcon className="h-5 w-5" />
+          ) : (
+            <PencilIcon className="h-5 w-5" />
+          )}
+        </Button>
       </div>
       <DeleteConfirmDialog
         open={deleteDialog.isOpen}


### PR DESCRIPTION
## Summary
- ツールバーを横スクロール可能に変更
- 保存ステータスをアイコンのみ表示に変更（ホバーでツールチップ表示）
- 削除・エクスポートをDropdown Menu内に配置
- ヘッダーから編集/閲覧モードボタンを削除
- FABボタンで編集/閲覧モードを切り替え可能に

## Changes
- `TiptapEditor.tsx`: ツールバーを `flex-wrap` から `overflow-x-auto` に変更して横スクロール対応
- `SaveStatusIndicator.tsx`: テキスト表示を削除してアイコンのみに変更、親要素にtitle属性を追加
- `NoteActions.tsx`: Export/Deleteボタンを `MoreVertical` アイコンのDropdown Menuに統合
- `MemoHeader.tsx`: 編集/閲覧モード切り替えボタンと関連propsを削除
- `memos.$id.tsx`: 画面右下にFAB (Floating Action Button) を追加し、編集/閲覧モードを切り替え可能に

## Test plan
- [x] ツールバーが折り返されず、横スクロールできることを確認
- [x] 保存ステータスがアイコンのみで表示され、ホバーで状態が確認できることを確認
- [x] ヘッダーに編集/閲覧モード切り替えボタンがないことを確認
- [x] MoreVerticalアイコンをクリックしてDropdown Menuが表示され、Export/Deleteが実行できることを確認
- [x] 画面右下のFABボタンで編集/閲覧モードが切り替えられることを確認
- [x] lint/formatが正常に完了することを確認

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)