### PR TITLE
fix: add @tiptap/core as explicit dependency to resolve type errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@react-router/node": "^7.9.2",
     "@react-router/serve": "^7.9.2",
+    "@tiptap/core": "^3.6.6",
     "@tiptap/extension-link": "^3.6.6",
     "@tiptap/extension-placeholder": "^3.6.6",
     "@tiptap/pm": "^3.6.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       '@react-router/serve':
         specifier: ^7.9.2
         version: 7.9.4(react-router@7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
+      '@tiptap/core':
+        specifier: ^3.6.6
+        version: 3.6.6(@tiptap/pm@3.6.6)
       '@tiptap/extension-link':
         specifier: ^3.6.6
         version: 3.6.6(@tiptap/core@3.6.6(@tiptap/pm@3.6.6))(@tiptap/pm@3.6.6)


### PR DESCRIPTION
## Summary

- Added `@tiptap/core` as an explicit dependency to resolve TypeScript type errors
- Fixed "Cannot find module '@tiptap/core'" error in `app/components/editor/TiptapEditor.tsx:1`

## Problem

The TypeScript compiler was unable to find the `@tiptap/core` module when importing types, even though it was indirectly available through `@tiptap/react`. This was because `@tiptap/core` was only listed as a devDependency of `@tiptap/react`, not as a direct dependency of the project.

## Solution

Added `@tiptap/core@^3.6.6` as a direct dependency in `package.json` to ensure TypeScript can properly resolve the module and its types.

## Test plan

- [x] Run `pnpm typecheck` to verify no type errors
- [x] Verify the module can be imported correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)