### PR TITLE
fix: resolve all Biome linter errors

### DIFF
--- a/app/components/note/NoteList.tsx
+++ b/app/components/note/NoteList.tsx
@@ -29,7 +29,7 @@ export function NoteList({
   onToggleSelect,
   onLoadMore,
 }: NoteListProps) {
-  const { query, sortField, sortOrder, tagIds } = useSearch();
+  const { query, tagIds } = useSearch();
   const hasFilters = !!query || tagIds.length > 0;
   const targetRef = useInfiniteScroll({
     onLoadMore,

--- a/app/components/note/SaveStatusIndicator.tsx
+++ b/app/components/note/SaveStatusIndicator.tsx
@@ -16,9 +16,7 @@ export function SaveStatusIndicator({ status }: SaveStatusIndicatorProps) {
 
   return (
     <div className="flex items-center text-muted-foreground" title={statusText}>
-      {status === "saved" && (
-        <CheckIcon className="h-4 w-4 text-green-600" />
-      )}
+      {status === "saved" && <CheckIcon className="h-4 w-4 text-green-600" />}
       {status === "saving" && <Spinner className="h-4 w-4" />}
       {status === "unsaved" && <SaveIcon className="h-4 w-4" />}
     </div>

--- a/app/context/di.tsx
+++ b/app/context/di.tsx
@@ -1,6 +1,5 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import { Spinner } from "@/components/ui/spinner";
-import type { Database } from "@/core/adapters/tursoWasm/client";
 import type { Container } from "@/core/application/container";
 import { createLocalStorageContainer, createTursoWasmContainer } from "@/di";
 import { useDatabase } from "@/hooks/useDatabase";

--- a/app/core/adapters/localStorage/noteQueryService.test.ts
+++ b/app/core/adapters/localStorage/noteQueryService.test.ts
@@ -2,7 +2,6 @@
  * LocalStorage Note Query Service Tests
  */
 import { beforeEach, describe, expect, it } from "vitest";
-import { createNoteId } from "@/core/domain/note/valueObject";
 import { createTagId } from "@/core/domain/tag/valueObject";
 import { LocalStorageNoteQueryService } from "./noteQueryService";
 
@@ -33,7 +32,7 @@ describe("LocalStorageNoteQueryService", () => {
 
   beforeEach(() => {
     localStorageMock = new LocalStorageMock();
-    global.localStorage = localStorageMock as any;
+    global.localStorage = localStorageMock as unknown as Storage;
     service = new LocalStorageNoteQueryService();
   });
 

--- a/app/core/adapters/localStorage/noteRepository.test.ts
+++ b/app/core/adapters/localStorage/noteRepository.test.ts
@@ -2,12 +2,7 @@
  * LocalStorage Note Repository Tests
  */
 import { beforeEach, describe, expect, it } from "vitest";
-import {
-  NotFoundError,
-  NotFoundErrorCode,
-  SystemError,
-  SystemErrorCode,
-} from "@/core/application/error";
+import { NotFoundError, SystemError } from "@/core/application/error";
 import type { Note } from "@/core/domain/note/entity";
 import {
   createNoteContent,
@@ -44,7 +39,7 @@ describe("LocalStorageNoteRepository", () => {
 
   beforeEach(() => {
     localStorageMock = new LocalStorageMock();
-    global.localStorage = localStorageMock as any;
+    global.localStorage = localStorageMock as unknown as Storage;
     repository = new LocalStorageNoteRepository();
   });
 
@@ -63,7 +58,7 @@ describe("LocalStorageNoteRepository", () => {
 
       const stored = localStorageMock.getItem("app_notes");
       expect(stored).toBeTruthy();
-      const parsed = JSON.parse(stored!);
+      const parsed = JSON.parse(stored as string);
       expect(parsed["test-id-1"]).toBeDefined();
       expect(parsed["test-id-1"].text).toBe("Test note");
       // Verify timestamps are in seconds
@@ -85,7 +80,7 @@ describe("LocalStorageNoteRepository", () => {
 
       const relations = localStorageMock.getItem("app_note_tag_relations");
       expect(relations).toBeTruthy();
-      const parsed = JSON.parse(relations!);
+      const parsed = JSON.parse(relations as string);
       expect(parsed).toHaveLength(2);
       expect(parsed[0]).toEqual({ note_id: "test-id-1", tag_id: "tag-1" });
       expect(parsed[1]).toEqual({ note_id: "test-id-1", tag_id: "tag-2" });
@@ -103,12 +98,7 @@ describe("LocalStorageNoteRepository", () => {
 
       // Mock setItem to throw QuotaExceededError
       localStorageMock.setItem = () => {
-        const error = new DOMException(
-          "QuotaExceededError",
-          "QuotaExceededError",
-        );
-        (error as any).name = "QuotaExceededError";
-        throw error;
+        throw new DOMException("QuotaExceededError", "QuotaExceededError");
       };
 
       await expect(repository.save(note)).rejects.toThrow(SystemError);
@@ -306,7 +296,7 @@ describe("LocalStorageNoteRepository", () => {
       await repository.delete(createNoteId("test-id-1"));
 
       const stored = localStorageMock.getItem("app_notes");
-      const parsed = JSON.parse(stored!);
+      const parsed = JSON.parse(stored as string);
       expect(parsed["test-id-1"]).toBeUndefined();
     });
 
@@ -332,7 +322,7 @@ describe("LocalStorageNoteRepository", () => {
       await repository.delete(createNoteId("test-id-1"));
 
       const relations = localStorageMock.getItem("app_note_tag_relations");
-      const parsed = JSON.parse(relations!);
+      const parsed = JSON.parse(relations as string);
       expect(parsed).toHaveLength(1);
       expect(parsed[0].note_id).toBe("test-id-2");
     });

--- a/app/core/adapters/localStorage/tagQueryService.test.ts
+++ b/app/core/adapters/localStorage/tagQueryService.test.ts
@@ -2,7 +2,6 @@
  * LocalStorage Tag Query Service Tests
  */
 import { beforeEach, describe, expect, it } from "vitest";
-import { createTagId } from "@/core/domain/tag/valueObject";
 import { LocalStorageTagQueryService } from "./tagQueryService";
 
 // Mock localStorage for testing
@@ -32,7 +31,7 @@ describe("LocalStorageTagQueryService", () => {
 
   beforeEach(() => {
     localStorageMock = new LocalStorageMock();
-    global.localStorage = localStorageMock as any;
+    global.localStorage = localStorageMock as unknown as Storage;
     service = new LocalStorageTagQueryService();
   });
 

--- a/app/core/adapters/localStorage/tagRepository.test.ts
+++ b/app/core/adapters/localStorage/tagRepository.test.ts
@@ -34,7 +34,7 @@ describe("LocalStorageTagRepository", () => {
 
   beforeEach(() => {
     localStorageMock = new LocalStorageMock();
-    global.localStorage = localStorageMock as any;
+    global.localStorage = localStorageMock as unknown as Storage;
     repository = new LocalStorageTagRepository();
   });
 
@@ -51,7 +51,7 @@ describe("LocalStorageTagRepository", () => {
 
       const stored = localStorageMock.getItem("app_tags");
       expect(stored).toBeTruthy();
-      const parsed = JSON.parse(stored!);
+      const parsed = JSON.parse(stored as string);
       expect(parsed["tag-1"]).toBeDefined();
       expect(parsed["tag-1"].name).toBe("TestTag");
       // Verify timestamps are in seconds
@@ -69,12 +69,7 @@ describe("LocalStorageTagRepository", () => {
 
       // Mock setItem to throw QuotaExceededError
       localStorageMock.setItem = () => {
-        const error = new DOMException(
-          "QuotaExceededError",
-          "QuotaExceededError",
-        );
-        (error as any).name = "QuotaExceededError";
-        throw error;
+        throw new DOMException("QuotaExceededError", "QuotaExceededError");
       };
 
       await expect(repository.save(tag)).rejects.toThrow(SystemError);
@@ -244,7 +239,7 @@ describe("LocalStorageTagRepository", () => {
       await repository.delete(createTagId("tag-1"));
 
       const stored = localStorageMock.getItem("app_tags");
-      const parsed = JSON.parse(stored!);
+      const parsed = JSON.parse(stored as string);
       expect(parsed["tag-1"]).toBeUndefined();
     });
 
@@ -269,7 +264,7 @@ describe("LocalStorageTagRepository", () => {
       await repository.delete(createTagId("tag-1"));
 
       const relations = localStorageMock.getItem("app_note_tag_relations");
-      const parsed = JSON.parse(relations!);
+      const parsed = JSON.parse(relations as string);
       expect(parsed).toHaveLength(1);
       expect(parsed[0].tag_id).toBe("tag-2");
     });
@@ -303,7 +298,7 @@ describe("LocalStorageTagRepository", () => {
       await repository.deleteMany([createTagId("tag-1"), createTagId("tag-2")]);
 
       const stored = localStorageMock.getItem("app_tags");
-      const parsed = JSON.parse(stored!);
+      const parsed = JSON.parse(stored as string);
       expect(parsed["tag-1"]).toBeUndefined();
       expect(parsed["tag-2"]).toBeUndefined();
       expect(parsed["tag-3"]).toBeDefined();
@@ -337,7 +332,7 @@ describe("LocalStorageTagRepository", () => {
       await repository.deleteMany([createTagId("tag-1"), createTagId("tag-2")]);
 
       const relations = localStorageMock.getItem("app_note_tag_relations");
-      const parsed = JSON.parse(relations!);
+      const parsed = JSON.parse(relations as string);
       expect(parsed).toHaveLength(1);
       expect(parsed[0].tag_id).toBe("tag-3");
     });
@@ -356,7 +351,7 @@ describe("LocalStorageTagRepository", () => {
       await repository.deleteMany([]);
 
       const stored = localStorageMock.getItem("app_tags");
-      const parsed = JSON.parse(stored!);
+      const parsed = JSON.parse(stored as string);
       expect(parsed["tag-1"]).toBeDefined();
     });
   });

--- a/app/core/application/note/createNote.test.ts
+++ b/app/core/application/note/createNote.test.ts
@@ -9,6 +9,7 @@ import { EmptyTagExtractorPort } from "@/core/adapters/empty/tagExtractorPort";
 import { EmptyTagQueryService } from "@/core/adapters/empty/tagQueryService";
 import { EmptyUnitOfWorkProvider } from "@/core/adapters/empty/unitOfWork";
 import { BusinessRuleError } from "@/core/domain/error";
+import type { StructuredContent } from "@/core/domain/note/valueObject";
 import type { Context } from "../context";
 import { createNote } from "./createNote";
 
@@ -183,14 +184,14 @@ describe("createNote", () => {
   it("無効なcontentでメモ作成時に例外が発生する（typeフィールドなし）", async () => {
     await expect(
       createNote(context, {
-        content: { content: [] } as any,
+        content: { content: [] } as unknown as StructuredContent,
         text: "テストメモ",
       }),
     ).rejects.toThrow(BusinessRuleError);
 
     await expect(
       createNote(context, {
-        content: { content: [] } as any,
+        content: { content: [] } as unknown as StructuredContent,
         text: "テストメモ",
       }),
     ).rejects.toThrow("Note content must have required field 'type'");
@@ -199,14 +200,14 @@ describe("createNote", () => {
   it("contentがnullの場合に例外が発生する", async () => {
     await expect(
       createNote(context, {
-        content: null as any,
+        content: null as unknown as StructuredContent,
         text: "テストメモ",
       }),
     ).rejects.toThrow(BusinessRuleError);
 
     await expect(
       createNote(context, {
-        content: null as any,
+        content: null as unknown as StructuredContent,
         text: "テストメモ",
       }),
     ).rejects.toThrow("Note content must be a valid JSON object");

--- a/app/core/application/note/updateNote.ts
+++ b/app/core/application/note/updateNote.ts
@@ -35,7 +35,7 @@ export async function updateNote(
     let tagNames: string[] = [];
     try {
       tagNames = await context.tagExtractorPort.extractTags(updatedNote.text);
-    } catch (error) {
+    } catch (_error) {
       // Silently ignore tag extraction errors
       // Logging strategy is a future consideration
     }
@@ -61,7 +61,7 @@ export async function updateNote(
             const newTag = createTag({ name: tagName });
             await repositories.tagRepository.save(newTag);
             return newTag;
-          } catch (error) {
+          } catch (_error) {
             // Skip invalid tag names
             // Logging strategy is a future consideration
             return null;

--- a/app/core/application/tag/syncNoteTags.ts
+++ b/app/core/application/tag/syncNoteTags.ts
@@ -28,7 +28,7 @@ export async function syncNoteTags(
     let tagNames: string[] = [];
     try {
       tagNames = await context.tagExtractorPort.extractTags(note.text);
-    } catch (error) {
+    } catch (_error) {
       // Silently ignore tag extraction errors
       // Logging strategy is a future consideration
     }
@@ -54,7 +54,7 @@ export async function syncNoteTags(
             const newTag = createTag({ name: tagName });
             await repositories.tagRepository.save(newTag);
             return newTag;
-          } catch (error) {
+          } catch (_error) {
             // Skip invalid tag names
             // Logging strategy is a future consideration
             return null;

--- a/app/hooks/useNote.ts
+++ b/app/hooks/useNote.ts
@@ -1,9 +1,8 @@
-import { use, useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { deleteNote as deleteNoteService } from "@/core/application/note/deleteNote";
 import { exportNoteAsMarkdown as exportNoteWithMarkdownService } from "@/core/application/note/exportNoteAsMarkdown";
 import { getNote as getNoteService } from "@/core/application/note/getNote";
 import { updateNote as updateNoteService } from "@/core/application/note/updateNote";
-import type { Note } from "@/core/domain/note/entity";
 import type { StructuredContent } from "@/core/domain/note/valueObject";
 import { createNoteId } from "@/core/domain/note/valueObject";
 import { withContainer } from "@/di";
@@ -11,7 +10,7 @@ import { formatError } from "@/presenters/error";
 import type { Notification } from "@/presenters/notification";
 import { request } from "@/presenters/request";
 
-const getNote = withContainer(getNoteService);
+const _getNote = withContainer(getNoteService);
 const updateNote = withContainer(updateNoteService);
 const deleteNote = withContainer(deleteNoteService);
 const exportNoteAsMarkdown = withContainer(exportNoteWithMarkdownService);

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -5,7 +5,6 @@ import { CreateNoteFAB } from "@/components/note/CreateNoteFAB";
 import { NoteList } from "@/components/note/NoteList";
 import { TagSidebar } from "@/components/tag/TagSidebar";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
-import { useDIContainer } from "@/context/di";
 import { SearchProvider } from "@/context/search";
 import { combinedSearch as combinedSearchService } from "@/core/application/note/combinedSearch";
 import { withContainer } from "@/di";

--- a/app/routes/memos.$id.tsx
+++ b/app/routes/memos.$id.tsx
@@ -5,7 +5,6 @@ import { TiptapEditor } from "@/components/editor/TiptapEditor";
 import { MemoHeader } from "@/components/layout/MemoHeader";
 import { DeleteConfirmDialog } from "@/components/note/DeleteConfirmDialog";
 import { Button } from "@/components/ui/button";
-import { Spinner } from "@/components/ui/spinner";
 import { getNote as getNoteService } from "@/core/application/note/getNote";
 import { createNoteId } from "@/core/domain/note/valueObject";
 import { withContainer } from "@/di";


### PR DESCRIPTION
## Summary

このPRでは、Biome linterで検出されたすべてのエラーを修正しました。

### 主な修正内容

- **未使用変数の削除**: `NoteList.tsx`の`sortField`と`sortOrder`を削除
- **未使用インポートの削除**: 複数のファイルで不要なインポートを削除
- **型安全性の向上**: 
  - テストファイルの`as any`を`as unknown as Storage`や`as unknown as StructuredContent`に変更
  - non-null assertion (`!`) を`as string`に変更
- **コードの簡潔化**: DOMExceptionの不要なnameプロパティ代入を削除

### 変更ファイル (13ファイル)

- `app/components/note/NoteList.tsx`
- `app/components/note/SaveStatusIndicator.tsx`
- `app/context/di.tsx`
- `app/core/adapters/localStorage/*.test.ts` (4ファイル)
- `app/core/application/note/createNote.test.ts`
- `app/core/application/note/updateNote.ts`
- `app/core/application/tag/syncNoteTags.ts`
- `app/hooks/useNote.ts`
- `app/routes/home.tsx`
- `app/routes/memos.$id.tsx`

## Test plan

- [x] `pnpm lint` - リンターエラーなし
- [x] `pnpm typecheck` - 型チェック通過
- [x] `pnpm format` - フォーマット通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>