### PR TITLE
feat: Add confirmation dialog when deleting a Note

### DIFF
--- a/app/hooks/useDialog.ts
+++ b/app/hooks/useDialog.ts
@@ -21,6 +21,7 @@ export function useDialog(initialOpen = false): DialogState {
 
   return {
     isOpen,
+    setOpen: setIsOpen,
     open,
     close,
     toggle,

--- a/app/routes/memos.$id.tsx
+++ b/app/routes/memos.$id.tsx
@@ -70,7 +70,7 @@ export function _MemoDetail(props: { fetchNote: ReturnType<typeof getNote> }) {
         saveStatus={saveStatus}
         exporting={exporting}
         onExport={exportNote}
-        onDelete={deleteNote}
+        onDelete={deleteDialog.open}
       />
       <div className="flex-1 overflow-hidden p-4 relative">
         <div className="h-full bg-card rounded-xl border shadow-sm">
@@ -98,7 +98,7 @@ export function _MemoDetail(props: { fetchNote: ReturnType<typeof getNote> }) {
       <DeleteConfirmDialog
         open={deleteDialog.isOpen}
         deleting={deleting}
-        onOpenChange={deleteDialog.close}
+        onOpenChange={deleteDialog.setOpen}
         onConfirm={handleDelete}
       />
     </div>

--- a/app/types/ui.ts
+++ b/app/types/ui.ts
@@ -14,6 +14,7 @@ export type SaveStatus = "saved" | "saving" | "unsaved";
  */
 export interface DialogState {
   isOpen: boolean;
+  setOpen: (open: boolean) => void;
   open: () => void;
   close: () => void;
   toggle: () => void;


### PR DESCRIPTION
This PR adds a confirmation dialog when deleting a Note, as requested in issue #23.

## Changes
- Updated `app/routes/memos.$id.tsx` to open DeleteConfirmDialog instead of directly calling deleteNote
- Enhanced `useDialog` hook to include `setOpen` method for AlertDialog compatibility
- Updated `DialogState` type to support `setOpen` method

Closes #23

Generated with [Claude Code](https://claude.ai/code)