### PR TITLE
feat: introduce custom article styles for editor

### DIFF
--- a/app/components/editor/TiptapEditor.tsx
+++ b/app/components/editor/TiptapEditor.tsx
@@ -109,7 +109,7 @@ export function TiptapEditor({
     editorProps: {
       attributes: {
         class:
-          "prose prose-sm sm:prose lg:prose-lg xl:prose-xl focus:outline-none max-w-none p-4 min-h-[calc(100vh-200px)]",
+          "article focus:outline-none max-w-none py-8 px-4 min-h-[calc(100vh-200px)]",
       },
     },
     immediatelyRender: false,

--- a/app/styles/index.css
+++ b/app/styles/index.css
@@ -3,6 +3,7 @@
 @import "./themes/candyland.css";
 @import "./typography.css";
 @import "./tweakcn.css";
+@import "./utilities/article.css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/app/styles/utilities/article.css
+++ b/app/styles/utilities/article.css
@@ -1,0 +1,164 @@
+@layer utilities {
+  .article {
+    * {
+      letter-spacing: 0.04em;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      margin-top: 3rem;
+      font-weight: var(--font-weight-bold);
+      line-height: 1.4;
+      text-wrap: initial;
+      word-break: auto-phrase;
+      letter-spacing: 0em;
+      font-feature-settings: "palt";
+    }
+
+    p,
+    ul,
+    ol,
+    table,
+    img,
+    pre,
+    blockquote,
+    dl,
+    iframe {
+      margin-top: 1.75rem;
+    }
+
+    p + p {
+      margin-top: 1.75rem;
+    }
+
+    h1 {
+      font-size: 2.25em;
+
+      @media only screen and (max-width: 640px) {
+        font-size: 1.75rem;
+      }
+    }
+
+    h2 {
+      font-size: 1.75em;
+
+      @media only screen and (max-width: 640px) {
+        font-size: 1.5rem;
+      }
+    }
+
+    h3 {
+      padding-bottom: 0.25rem;
+      border-bottom: 2px solid var(--colors-border);
+      font-size: 1.25em;
+    }
+
+    h4 {
+      font-size: 1.1em;
+    }
+
+    h5 {
+      font-size: 1em;
+    }
+
+    a {
+      text-decoration: underline;
+    }
+
+    hr {
+      margin: 4rem 0;
+      width: 100%;
+      height: 2px;
+      border: none;
+      background-color: #f0f0f0;
+    }
+
+    div:has(table) {
+      overflow-x: scroll;
+    }
+
+    table {
+      min-width: 100%;
+    }
+
+    th {
+      text-align: center;
+    }
+
+    td:first-child {
+      vertical-align: middle;
+    }
+
+    th,
+    td {
+      white-space: nowrap;
+    }
+
+    ul {
+      padding-left: 1.75rem;
+      list-style: disc;
+    }
+
+    ol {
+      padding-left: 1.75rem;
+      list-style: decimal;
+    }
+
+    td ul,
+    li ul,
+    td ol,
+    li ol {
+      margin-top: 0;
+    }
+
+    li {
+      padding: 0.15rem 0;
+    }
+
+    pre {
+      padding: var(--spacing-s-200);
+      background-color: #f0f0f0;
+      line-height: 1.5;
+      border-radius: var(--radii-md);
+      overflow: scroll;
+    }
+
+    code {
+      padding: 0.2rem 0.4rem;
+      background-color: #f0f0f0 !important;
+      border-radius: var(--radii-md);
+    }
+
+    code,
+    code * {
+      font-family: var(--fonts-mono);
+      line-height: 1.5;
+      letter-spacing: 0;
+    }
+
+    pre > code {
+      padding: 0 !important;
+    }
+
+    blockquote {
+      padding: var(--spacing-s-100);
+      border-left: 2px solid var(--colors-border);
+    }
+
+    img {
+      max-width: 100%;
+    }
+
+    *:first-child {
+      margin-top: 0;
+    }
+
+    *:last-child {
+      margin-bottom: 0;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Replace Tailwind prose classes with custom article utility for better typography control
- Add comprehensive styles for headings, lists, code blocks, tables, and other content elements
- Improve Japanese typography with letter-spacing and font-feature-settings

## Test plan
- [ ] Verify editor renders correctly with new styles
- [ ] Test all content types (headings, lists, code, tables, blockquotes, images)
- [ ] Check responsive behavior on mobile devices
- [ ] Ensure Japanese text displays properly with improved typography

🤖 Generated with [Claude Code](https://claude.com/claude-code)