### PR TITLE
fix: add missing TagCleanupService and TagSyncService to dependency injection

### DIFF
--- a/app/container.tsx
+++ b/app/container.tsx
@@ -7,6 +7,7 @@ import { DrizzleSqliteNoteQueryService } from "@/core/adapters/drizzleSqlite/not
 import { DrizzleSqliteTagQueryService } from "@/core/adapters/drizzleSqlite/tagQueryService";
 import { DrizzleSqliteUnitOfWorkProvider } from "@/core/adapters/drizzleSqlite/unitOfWork";
 import type { Context } from "@/core/application/context";
+import { TagCleanupService, TagSyncService } from "@/core/domain/tag/service";
 
 export type Container = Context;
 
@@ -28,6 +29,8 @@ function createContainer(): Context {
     unitOfWorkProvider: new DrizzleSqliteUnitOfWorkProvider(db),
     noteQueryService: new DrizzleSqliteNoteQueryService(db),
     tagQueryService: new DrizzleSqliteTagQueryService(db),
+    tagCleanupService: new TagCleanupService(),
+    tagSyncService: new TagSyncService(),
     exportPort: new BrowserExportPort(),
     tagExtractorPort: new BrowserTagExtractorPort(),
     settingsRepository: new BrowserSettingsRepository(),

--- a/app/core/application/container.ts
+++ b/app/core/application/container.ts
@@ -3,7 +3,10 @@ import type { NoteQueryService } from "@/core/domain/note/ports/noteQueryService
 import type { SettingsRepository } from "@/core/domain/settings/ports/settingsRepository";
 import type { TagExtractorPort } from "@/core/domain/tag/ports/tagExtractorPort";
 import type { TagQueryService } from "@/core/domain/tag/ports/tagQueryService";
-import type { TagCleanupService, TagSyncService } from "@/core/domain/tag/service";
+import type {
+  TagCleanupService,
+  TagSyncService,
+} from "@/core/domain/tag/service";
 import type { UnitOfWorkProvider } from "./unitOfWork";
 
 /**

--- a/app/core/application/context.ts
+++ b/app/core/application/context.ts
@@ -3,7 +3,10 @@ import type { NoteQueryService } from "@/core/domain/note/ports/noteQueryService
 import type { SettingsRepository } from "@/core/domain/settings/ports/settingsRepository";
 import type { TagExtractorPort } from "@/core/domain/tag/ports/tagExtractorPort";
 import type { TagQueryService } from "@/core/domain/tag/ports/tagQueryService";
-import type { TagCleanupService, TagSyncService } from "@/core/domain/tag/service";
+import type {
+  TagCleanupService,
+  TagSyncService,
+} from "@/core/domain/tag/service";
 import type { UnitOfWorkProvider } from "./unitOfWork";
 
 /**

--- a/app/core/application/note/combinedSearch.test.ts
+++ b/app/core/application/note/combinedSearch.test.ts
@@ -10,6 +10,7 @@ import { EmptyTagQueryService } from "@/core/adapters/empty/tagQueryService";
 import { EmptyUnitOfWorkProvider } from "@/core/adapters/empty/unitOfWork";
 import { createNote } from "@/core/domain/note/entity";
 import { createTagId } from "@/core/domain/tag/valueObject";
+import { TagCleanupService, TagSyncService } from "@/core/domain/tag/service";
 import type { Context } from "../context";
 import { combinedSearch } from "./combinedSearch";
 import { createTestContent } from "./test-helpers";
@@ -24,6 +25,8 @@ describe("combinedSearch", () => {
       unitOfWorkProvider,
       noteQueryService: new EmptyNoteQueryService(),
       tagQueryService: new EmptyTagQueryService(),
+      tagCleanupService: new TagCleanupService(),
+      tagSyncService: new TagSyncService(),
       exportPort: new EmptyExportPort(),
       tagExtractorPort: new EmptyTagExtractorPort(),
       settingsRepository: new EmptySettingsRepository(),

--- a/app/core/application/note/createNote.test.ts
+++ b/app/core/application/note/createNote.test.ts
@@ -10,6 +10,7 @@ import { EmptyTagQueryService } from "@/core/adapters/empty/tagQueryService";
 import { EmptyUnitOfWorkProvider } from "@/core/adapters/empty/unitOfWork";
 import { BusinessRuleError } from "@/core/domain/error";
 import type { StructuredContent } from "@/core/domain/note/valueObject";
+import { TagCleanupService, TagSyncService } from "@/core/domain/tag/service";
 import type { Context } from "../context";
 import { createNote } from "./createNote";
 
@@ -23,6 +24,8 @@ describe("createNote", () => {
       unitOfWorkProvider,
       noteQueryService: new EmptyNoteQueryService(),
       tagQueryService: new EmptyTagQueryService(),
+      tagCleanupService: new TagCleanupService(),
+      tagSyncService: new TagSyncService(),
       exportPort: new EmptyExportPort(),
       tagExtractorPort: new EmptyTagExtractorPort(),
       settingsRepository: new EmptySettingsRepository(),

--- a/app/core/application/note/deleteNote.test.ts
+++ b/app/core/application/note/deleteNote.test.ts
@@ -10,6 +10,7 @@ import { EmptyTagQueryService } from "@/core/adapters/empty/tagQueryService";
 import { EmptyUnitOfWorkProvider } from "@/core/adapters/empty/unitOfWork";
 import { createNote } from "@/core/domain/note/entity";
 import { createNoteId } from "@/core/domain/note/valueObject";
+import { TagCleanupService, TagSyncService } from "@/core/domain/tag/service";
 import type { Context } from "../context";
 import { NotFoundError } from "../error";
 import { deleteNote } from "./deleteNote";
@@ -25,6 +26,8 @@ describe("deleteNote", () => {
       unitOfWorkProvider,
       noteQueryService: new EmptyNoteQueryService(),
       tagQueryService: new EmptyTagQueryService(),
+      tagCleanupService: new TagCleanupService(),
+      tagSyncService: new TagSyncService(),
       exportPort: new EmptyExportPort(),
       tagExtractorPort: new EmptyTagExtractorPort(),
       settingsRepository: new EmptySettingsRepository(),

--- a/app/core/application/note/exportNoteAsMarkdown.test.ts
+++ b/app/core/application/note/exportNoteAsMarkdown.test.ts
@@ -10,6 +10,7 @@ import { EmptyTagQueryService } from "@/core/adapters/empty/tagQueryService";
 import { EmptyUnitOfWorkProvider } from "@/core/adapters/empty/unitOfWork";
 import { createNote } from "@/core/domain/note/entity";
 import { createNoteId } from "@/core/domain/note/valueObject";
+import { TagCleanupService, TagSyncService } from "@/core/domain/tag/service";
 import type { Context } from "../context";
 import { NotFoundError } from "../error";
 import { exportNoteAsMarkdown } from "./exportNoteAsMarkdown";
@@ -25,6 +26,8 @@ describe("exportNoteAsMarkdown", () => {
       unitOfWorkProvider,
       noteQueryService: new EmptyNoteQueryService(),
       tagQueryService: new EmptyTagQueryService(),
+      tagCleanupService: new TagCleanupService(),
+      tagSyncService: new TagSyncService(),
       exportPort: new EmptyExportPort(),
       tagExtractorPort: new EmptyTagExtractorPort(),
       settingsRepository: new EmptySettingsRepository(),

--- a/app/core/application/note/exportNotesAsMarkdown.test.ts
+++ b/app/core/application/note/exportNotesAsMarkdown.test.ts
@@ -10,6 +10,7 @@ import { EmptyTagQueryService } from "@/core/adapters/empty/tagQueryService";
 import { EmptyUnitOfWorkProvider } from "@/core/adapters/empty/unitOfWork";
 import { createNote } from "@/core/domain/note/entity";
 import { createNoteId } from "@/core/domain/note/valueObject";
+import { TagCleanupService, TagSyncService } from "@/core/domain/tag/service";
 import type { Context } from "../context";
 import { NotFoundError } from "../error";
 import { exportNotesAsMarkdown } from "./exportNotesAsMarkdown";
@@ -25,6 +26,8 @@ describe("exportNotesAsMarkdown", () => {
       unitOfWorkProvider,
       noteQueryService: new EmptyNoteQueryService(),
       tagQueryService: new EmptyTagQueryService(),
+      tagCleanupService: new TagCleanupService(),
+      tagSyncService: new TagSyncService(),
       exportPort: new EmptyExportPort(),
       tagExtractorPort: new EmptyTagExtractorPort(),
       settingsRepository: new EmptySettingsRepository(),

--- a/app/core/application/note/getNote.test.ts
+++ b/app/core/application/note/getNote.test.ts
@@ -11,6 +11,7 @@ import { EmptyUnitOfWorkProvider } from "@/core/adapters/empty/unitOfWork";
 import { createNote } from "@/core/domain/note/entity";
 import { createNoteId } from "@/core/domain/note/valueObject";
 import { createTagId } from "@/core/domain/tag/valueObject";
+import { TagCleanupService, TagSyncService } from "@/core/domain/tag/service";
 import type { Context } from "../context";
 import { getNote } from "./getNote";
 import { createTestContent } from "./test-helpers";
@@ -25,6 +26,8 @@ describe("getNote", () => {
       unitOfWorkProvider,
       noteQueryService: new EmptyNoteQueryService(),
       tagQueryService: new EmptyTagQueryService(),
+      tagCleanupService: new TagCleanupService(),
+      tagSyncService: new TagSyncService(),
       exportPort: new EmptyExportPort(),
       tagExtractorPort: new EmptyTagExtractorPort(),
       settingsRepository: new EmptySettingsRepository(),

--- a/app/core/application/note/getNotes.test.ts
+++ b/app/core/application/note/getNotes.test.ts
@@ -11,6 +11,7 @@ import { EmptyUnitOfWorkProvider } from "@/core/adapters/empty/unitOfWork";
 import type { Note } from "@/core/domain/note/entity";
 import { createNote } from "@/core/domain/note/entity";
 import type { PaginationResult } from "@/lib/pagination";
+import { TagCleanupService, TagSyncService } from "@/core/domain/tag/service";
 import type { Context } from "../context";
 import { getNotes } from "./getNotes";
 import { createTestContent } from "./test-helpers";
@@ -25,6 +26,8 @@ describe("getNotes", () => {
       unitOfWorkProvider,
       noteQueryService: new EmptyNoteQueryService(),
       tagQueryService: new EmptyTagQueryService(),
+      tagCleanupService: new TagCleanupService(),
+      tagSyncService: new TagSyncService(),
       exportPort: new EmptyExportPort(),
       tagExtractorPort: new EmptyTagExtractorPort(),
       settingsRepository: new EmptySettingsRepository(),

--- a/app/core/application/note/searchNotesByTag.test.ts
+++ b/app/core/application/note/searchNotesByTag.test.ts
@@ -10,6 +10,7 @@ import { EmptyTagQueryService } from "@/core/adapters/empty/tagQueryService";
 import { EmptyUnitOfWorkProvider } from "@/core/adapters/empty/unitOfWork";
 import { createNote } from "@/core/domain/note/entity";
 import { createTagId } from "@/core/domain/tag/valueObject";
+import { TagCleanupService, TagSyncService } from "@/core/domain/tag/service";
 import type { Context } from "../context";
 import { searchNotesByTag } from "./searchNotesByTag";
 import { createTestContent } from "./test-helpers";
@@ -24,6 +25,8 @@ describe("searchNotesByTag", () => {
       unitOfWorkProvider,
       noteQueryService: new EmptyNoteQueryService(),
       tagQueryService: new EmptyTagQueryService(),
+      tagCleanupService: new TagCleanupService(),
+      tagSyncService: new TagSyncService(),
       exportPort: new EmptyExportPort(),
       tagExtractorPort: new EmptyTagExtractorPort(),
       settingsRepository: new EmptySettingsRepository(),

--- a/app/core/application/note/searchNotesByTags.test.ts
+++ b/app/core/application/note/searchNotesByTags.test.ts
@@ -10,6 +10,7 @@ import { EmptyTagQueryService } from "@/core/adapters/empty/tagQueryService";
 import { EmptyUnitOfWorkProvider } from "@/core/adapters/empty/unitOfWork";
 import { createNote } from "@/core/domain/note/entity";
 import { createTagId } from "@/core/domain/tag/valueObject";
+import { TagCleanupService, TagSyncService } from "@/core/domain/tag/service";
 import type { Context } from "../context";
 import { searchNotesByTags } from "./searchNotesByTags";
 import { createTestContent } from "./test-helpers";
@@ -24,6 +25,8 @@ describe("searchNotesByTags", () => {
       unitOfWorkProvider,
       noteQueryService: new EmptyNoteQueryService(),
       tagQueryService: new EmptyTagQueryService(),
+      tagCleanupService: new TagCleanupService(),
+      tagSyncService: new TagSyncService(),
       exportPort: new EmptyExportPort(),
       tagExtractorPort: new EmptyTagExtractorPort(),
       settingsRepository: new EmptySettingsRepository(),

--- a/app/core/application/settings/getSettings.test.ts
+++ b/app/core/application/settings/getSettings.test.ts
@@ -10,6 +10,7 @@ import { EmptyTagQueryService } from "@/core/adapters/empty/tagQueryService";
 import { EmptyUnitOfWorkProvider } from "@/core/adapters/empty/unitOfWork";
 import { DEFAULT_SETTINGS } from "@/core/domain/settings/entity";
 import { createAutoSaveInterval } from "@/core/domain/settings/valueObject";
+import { TagCleanupService, TagSyncService } from "@/core/domain/tag/service";
 import type { Context } from "../context";
 import { getSettings } from "./getSettings";
 
@@ -21,6 +22,8 @@ describe("getSettings", () => {
       unitOfWorkProvider: new EmptyUnitOfWorkProvider(),
       noteQueryService: new EmptyNoteQueryService(),
       tagQueryService: new EmptyTagQueryService(),
+      tagCleanupService: new TagCleanupService(),
+      tagSyncService: new TagSyncService(),
       exportPort: new EmptyExportPort(),
       tagExtractorPort: new EmptyTagExtractorPort(),
       settingsRepository: new EmptySettingsRepository(),

--- a/app/core/application/settings/resetSettings.test.ts
+++ b/app/core/application/settings/resetSettings.test.ts
@@ -8,6 +8,7 @@ import { EmptySettingsRepository } from "@/core/adapters/empty/settingsRepositor
 import { EmptyTagExtractorPort } from "@/core/adapters/empty/tagExtractorPort";
 import { EmptyTagQueryService } from "@/core/adapters/empty/tagQueryService";
 import { EmptyUnitOfWorkProvider } from "@/core/adapters/empty/unitOfWork";
+import { TagCleanupService, TagSyncService } from "@/core/domain/tag/service";
 import type { Context } from "../context";
 import { resetSettings } from "./resetSettings";
 
@@ -19,6 +20,8 @@ describe("resetSettings", () => {
       unitOfWorkProvider: new EmptyUnitOfWorkProvider(),
       noteQueryService: new EmptyNoteQueryService(),
       tagQueryService: new EmptyTagQueryService(),
+      tagCleanupService: new TagCleanupService(),
+      tagSyncService: new TagSyncService(),
       exportPort: new EmptyExportPort(),
       tagExtractorPort: new EmptyTagExtractorPort(),
       settingsRepository: new EmptySettingsRepository(),

--- a/app/core/application/settings/updateSettings.test.ts
+++ b/app/core/application/settings/updateSettings.test.ts
@@ -11,6 +11,7 @@ import { EmptyUnitOfWorkProvider } from "@/core/adapters/empty/unitOfWork";
 import { BusinessRuleError } from "@/core/domain/error";
 import { DEFAULT_SETTINGS } from "@/core/domain/settings/entity";
 import { createAutoSaveInterval } from "@/core/domain/settings/valueObject";
+import { TagCleanupService, TagSyncService } from "@/core/domain/tag/service";
 import type { Context } from "../context";
 import { updateSettings } from "./updateSettings";
 
@@ -22,6 +23,8 @@ describe("updateSettings", () => {
       unitOfWorkProvider: new EmptyUnitOfWorkProvider(),
       noteQueryService: new EmptyNoteQueryService(),
       tagQueryService: new EmptyTagQueryService(),
+      tagCleanupService: new TagCleanupService(),
+      tagSyncService: new TagSyncService(),
       exportPort: new EmptyExportPort(),
       tagExtractorPort: new EmptyTagExtractorPort(),
       settingsRepository: new EmptySettingsRepository(),

--- a/app/core/application/tag/deleteTagsByNote.test.ts
+++ b/app/core/application/tag/deleteTagsByNote.test.ts
@@ -11,6 +11,7 @@ import { EmptyUnitOfWorkProvider } from "@/core/adapters/empty/unitOfWork";
 import { createNote } from "@/core/domain/note/entity";
 import { createNoteId } from "@/core/domain/note/valueObject";
 import { createTag } from "@/core/domain/tag/entity";
+import { TagCleanupService, TagSyncService } from "@/core/domain/tag/service";
 import type { Context } from "../context";
 import { createTestContent } from "../note/test-helpers";
 import { deleteTagsByNote } from "./deleteTagsByNote";
@@ -25,6 +26,8 @@ describe("deleteTagsByNote", () => {
       unitOfWorkProvider,
       noteQueryService: new EmptyNoteQueryService(),
       tagQueryService: new EmptyTagQueryService(),
+      tagCleanupService: new TagCleanupService(),
+      tagSyncService: new TagSyncService(),
       exportPort: new EmptyExportPort(),
       tagExtractorPort: new EmptyTagExtractorPort(),
       settingsRepository: new EmptySettingsRepository(),

--- a/app/core/application/tag/getTags.test.ts
+++ b/app/core/application/tag/getTags.test.ts
@@ -10,6 +10,7 @@ import { EmptyTagQueryService } from "@/core/adapters/empty/tagQueryService";
 import { EmptyUnitOfWorkProvider } from "@/core/adapters/empty/unitOfWork";
 import type { TagWithUsage } from "@/core/domain/tag/entity";
 import { createTag } from "@/core/domain/tag/entity";
+import { TagCleanupService, TagSyncService } from "@/core/domain/tag/service";
 import type { Context } from "../context";
 import { getTags } from "./getTags";
 
@@ -23,6 +24,8 @@ describe("getTags", () => {
       unitOfWorkProvider,
       noteQueryService: new EmptyNoteQueryService(),
       tagQueryService: new EmptyTagQueryService(),
+      tagCleanupService: new TagCleanupService(),
+      tagSyncService: new TagSyncService(),
       exportPort: new EmptyExportPort(),
       tagExtractorPort: new EmptyTagExtractorPort(),
       settingsRepository: new EmptySettingsRepository(),

--- a/app/core/application/tag/getTagsByNote.test.ts
+++ b/app/core/application/tag/getTagsByNote.test.ts
@@ -11,6 +11,7 @@ import { EmptyUnitOfWorkProvider } from "@/core/adapters/empty/unitOfWork";
 import { createNote } from "@/core/domain/note/entity";
 import { createNoteId } from "@/core/domain/note/valueObject";
 import { createTag } from "@/core/domain/tag/entity";
+import { TagCleanupService, TagSyncService } from "@/core/domain/tag/service";
 import type { Context } from "../context";
 import { createTestContent } from "../note/test-helpers";
 import { getTagsByNote } from "./getTagsByNote";
@@ -25,6 +26,8 @@ describe("getTagsByNote", () => {
       unitOfWorkProvider,
       noteQueryService: new EmptyNoteQueryService(),
       tagQueryService: new EmptyTagQueryService(),
+      tagCleanupService: new TagCleanupService(),
+      tagSyncService: new TagSyncService(),
       exportPort: new EmptyExportPort(),
       tagExtractorPort: new EmptyTagExtractorPort(),
       settingsRepository: new EmptySettingsRepository(),

--- a/app/di.ts
+++ b/app/di.ts
@@ -30,8 +30,7 @@ const STORAGE_ADAPTER: StorageAdapter = (() => {
   return envAdapter as StorageAdapter;
 })();
 
-// biome-ignore lint/suspicious/noExplicitAny: any
-export function withContainer<T extends any[], K>(
+export function withContainer<T extends unknown[], K>(
   fn: (container: Container, ...args: T) => Promise<K>,
 ): (...args: T) => Promise<K> {
   return async (...args: T) => {

--- a/app/presenters/note.test.ts
+++ b/app/presenters/note.test.ts
@@ -63,7 +63,8 @@ describe("extractTitle", () => {
   });
 
   it("should truncate text to 50 characters with ellipsis", () => {
-    const longText = "This is a very long text that exceeds fifty characters and should be truncated";
+    const longText =
+      "This is a very long text that exceeds fifty characters and should be truncated";
     const content: StructuredContent = {
       type: "doc",
       content: [
@@ -209,7 +210,7 @@ describe("extractTitle", () => {
 
     const result = extractTitle(content);
     // Should truncate to 50 emoji + "..."
-    expect(result).toBe("🤖".repeat(50) + "...");
+    expect(result).toBe(`${"🤖".repeat(50)}...`);
     // Verify we have exactly 50 emoji characters (not counting the ellipsis)
     const withoutEllipsis = result.slice(0, -3);
     expect(Array.from(withoutEllipsis).length).toBe(50);


### PR DESCRIPTION
## Summary
- Add tagCleanupService and tagSyncService to DI container (app/container.tsx)
- Update all test files to include the new services in test contexts
- Fix linter error in note.test.ts (use template literal instead of string concatenation)

## Details

### Type Errors Fixed
Fixed 16 TypeScript compilation errors where Context type required `tagCleanupService` and `tagSyncService` but they were missing:
- **app/container.tsx** - Added both services to the DI container
- **Test files (15 files)** - Added both services to all test context initializations
  - app/core/application/note/* (8 files)
  - app/core/application/settings/* (3 files)  
  - app/core/application/tag/* (3 files)

### Linter Errors Fixed
Fixed 1 Biome linter error:
- **app/presenters/note.test.ts:213** - Changed string concatenation to template literal as recommended by `lint/style/useTemplate`

## Test Plan
- [x] Run `pnpm typecheck` - All type errors resolved
- [x] Run `pnpm lint` - All linter errors resolved
- [x] Verified all tests can properly initialize Context objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)